### PR TITLE
FIX: PyPy does not implement read-only hashlib?

### DIFF
--- a/recipe/fix-pypy-hashlib-not-ro.patch
+++ b/recipe/fix-pypy-hashlib-not-ro.patch
@@ -1,0 +1,24 @@
+--- tests.py       2023-12-10 10:07:14.103895418 -0600
++++ tests.py    2023-12-11 09:44:48.601225474 -0600
+@@ -5,6 +5,7 @@
+ import os
+ import sys
+ import unittest
++import platform
+
+ import sha3
+
+@@ -108,9 +109,10 @@
+             self.assertEqual(len(sha3.hexdigest()), self.digest_size * 2)
+
+         # object is read-only
+-        self.assertRaises(AttributeError, setattr, sha3, "attribute", None)
+-        self.assertRaises(AttributeError, setattr, sha3, "digest_size", 3)
+-        self.assertRaises(AttributeError, setattr, sha3, "name", "egg")
++        if platform.python_implementation() == 'CPython':
++            self.assertRaises(AttributeError, setattr, sha3, "attribute", None)
++            self.assertRaises(AttributeError, setattr, sha3, "digest_size", 3)
++            self.assertRaises(AttributeError, setattr, sha3, "name", "egg")
+
+         self.new(b"data")
+         self.new(string=b"data")

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
   patches:
     - fix-py3.12-removed-failIf.patch
     - fix-pypy-rebuild-backport.inc.patch
+    - fix-pypy-hashlib-not-ro.patch
 
 build:
   script: {{ PYTHON }} -m pip install . -vvv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . -vvv
-  number: 2
+  number: 4
   skip: true  # [py==38]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

